### PR TITLE
start/goal editor, seperate presets to seperate gui window

### DIFF
--- a/test/planner_debug.cpp
+++ b/test/planner_debug.cpp
@@ -64,11 +64,24 @@ void do_planner_debug(
   if (ImGui::TreeNode("Current Plan"))
   {
     ImGui::Text("-= Starts --");
+    
     for (uint i=0; i<starts.size(); ++i)
     {
       ImGui::PushID(i);
       ImGui::Text("Start #%d", i);
-      ImGui::Text("Time: %ld", starts[i].time().time_since_epoch().count());
+
+      auto duration_nano = starts[i].time() - plan_start_timing;
+      auto duration_milli = std::chrono::duration_cast<std::chrono::milliseconds>(duration_nano);
+      
+      static int time_offset = 0;
+      time_offset = duration_milli.count();
+      ImGui::InputInt("Time offset (ms)", &time_offset);
+      if (time_offset != duration_milli.count())
+      {
+        std::chrono::duration<int, std::milli> duration(time_offset);
+        starts[i].time(plan_start_timing + duration);
+        reset_planning = true;
+      }
 
       ImGuiStyle& style = ImGui::GetStyle();
       float w = ImGui::CalcItemWidth();

--- a/test/planner_debug.hpp
+++ b/test/planner_debug.hpp
@@ -55,8 +55,14 @@ void do_planner_debug(
   rmf_traffic::agv::Planner::Debug& debug,
   rmf_traffic::agv::Planner::Debug::Progress& progress,
   const std::chrono::steady_clock::time_point& plan_start_timing, // earliest time the timeline starts from
+  bool force_replan,
   bool& show_node_trajectories,
   std::vector<rmf_planner_viz::draw::Trajectory>& trajectories_to_render);
+
+bool do_planner_presets(
+  std::vector<rmf_traffic::agv::Planner::Start>& starts,
+  rmf_traffic::agv::Planner::Goal& goal,
+  const std::chrono::steady_clock::time_point& plan_start_timing);
 
 } // namespace draw
 } // namespace rmf_planner_viz

--- a/test/planner_debug.hpp
+++ b/test/planner_debug.hpp
@@ -51,6 +51,7 @@ void do_planner_debug(
   rmf_traffic::agv::Planner& planner,
   std::vector<rmf_traffic::agv::Planner::Start>& starts,
   rmf_traffic::agv::Planner::Goal& goal,
+  std::size_t graph_num_waypoints,
   rmf_traffic::agv::Planner::Debug& debug,
   rmf_traffic::agv::Planner::Debug::Progress& progress,
   const std::chrono::steady_clock::time_point& plan_start_timing, // earliest time the timeline starts from

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -187,10 +187,11 @@ int main()
 
 
   // set plans for the participants
-  const auto now = std::chrono::steady_clock::now();
+  using namespace std::chrono_literals;
+  auto plan_start_timing = std::chrono::steady_clock::now();
 
   std::vector<rmf_traffic::agv::Planner::Start> starts;
-  starts.emplace_back(now, 11, 0.0);
+  starts.emplace_back(plan_start_timing, 11, 0.0);
   // starts.emplace_back(now, 12, 0.0);
   // starts.emplace_back(now, 10, 0.0);
 
@@ -207,7 +208,7 @@ int main()
     planner_debug.begin(starts, goal, planner_0.get_default_options());
 
   rmf_planner_viz::draw::Schedule schedule_drawable(
-        database, 0.25, test_map_name, now);
+        database, 0.25, test_map_name, plan_start_timing);
 
   rmf_planner_viz::draw::Fit fit(
     {graph_0_drawable.bounds(), graph_1_drawable.bounds()}, 0.02);
@@ -257,10 +258,10 @@ int main()
     static bool show_node_trajectories = true;
     static std::vector<rmf_planner_viz::draw::Trajectory> trajectories_to_render;
 
-    bool force_replan = rmf_planner_viz::draw::do_planner_presets(starts, goal, now);
+    bool force_replan = rmf_planner_viz::draw::do_planner_presets(starts, goal, plan_start_timing);
 
     rmf_planner_viz::draw::do_planner_debug(
-      profile, planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, now,
+      profile, planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, plan_start_timing,
       force_replan, show_node_trajectories, trajectories_to_render);
     
     ImGui::EndFrame();

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -258,7 +258,7 @@ int main()
     static std::vector<rmf_planner_viz::draw::Trajectory> trajectories_to_render;
 
     rmf_planner_viz::draw::do_planner_debug(
-      profile, planner_0, starts, goal, planner_debug, progress, now,
+      profile, planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, now,
       show_node_trajectories, trajectories_to_render);
     
     ImGui::EndFrame();

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -257,9 +257,11 @@ int main()
     static bool show_node_trajectories = true;
     static std::vector<rmf_planner_viz::draw::Trajectory> trajectories_to_render;
 
+    bool force_replan = rmf_planner_viz::draw::do_planner_presets(starts, goal, now);
+
     rmf_planner_viz::draw::do_planner_debug(
       profile, planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, now,
-      show_node_trajectories, trajectories_to_render);
+      force_replan, show_node_trajectories, trajectories_to_render);
     
     ImGui::EndFrame();
 


### PR DESCRIPTION
temporarily uses graph_0 waypoints,
plan will restart from 0 steps whenever the start/goal is changed

![image](https://user-images.githubusercontent.com/3326941/101851735-15fdff00-3b97-11eb-85c5-1eb4a91533e5.png)

edit: add editable time offsets
