### PR TITLE
navgraph level filtering, center align text, add text indicating connections

### DIFF
--- a/include/rmf_planner_viz/draw/Graph.hpp
+++ b/include/rmf_planner_viz/draw/Graph.hpp
@@ -68,6 +68,9 @@ public:
   rmf_utils::optional<Pick> selected() const;
 
   void set_text_size(uint sz);
+
+  std::vector<std::string> get_map_names();
+
 protected:
 
   void draw(sf::RenderTarget& target, sf::RenderStates states) const final;

--- a/src/rmf_planner_viz/draw/Graph.cpp
+++ b/src/rmf_planner_viz/draw/Graph.cpp
@@ -461,9 +461,20 @@ void Graph::draw(sf::RenderTarget& target, sf::RenderStates states) const
 
 void Graph::set_text_size(uint sz)
 {
-  auto& map_data = _pimpl->data.at(*_pimpl->current_map);
-  for (auto& s : map_data.waypoints_text)
-    s.setCharacterSize(sz);
+  for (auto& iter : _pimpl->data)
+  {
+    auto& map_data = iter.second;
+    for (auto& s : map_data.waypoints_text)
+      s.setCharacterSize(sz);
+  }
+}
+
+std::vector<std::string> Graph::get_map_names()
+{
+  std::vector<std::string> names;
+  for (auto& s : _pimpl->data)
+    names.push_back(s.first);
+  return names;
 }
 
 } // namespace draw

--- a/src/rmf_planner_viz/draw/Graph.cpp
+++ b/src/rmf_planner_viz/draw/Graph.cpp
@@ -30,6 +30,8 @@
 namespace rmf_planner_viz {
 namespace draw {
 
+static const sf::Vector2f gTextScale(1.f/40.f, -1.f/40.f);
+
 //==============================================================================
 class Graph::Implementation
 {
@@ -46,7 +48,8 @@ public:
     std::vector<sf::VertexArray> mono_lane_arrows;
 
     std::vector<sf::CircleShape> waypoints;
-    std::vector<sf::Text> waypoints_text;
+    std::unordered_map<std::size_t, sf::Text> waypoints_text;
+    std::unordered_map<std::size_t, sf::Text> connector_waypoints_text;
     std::vector<Eigen::Vector2f> waypoint_p;
     std::vector<std::size_t> waypoint_indices;
   };
@@ -85,7 +88,7 @@ public:
     this->lane_width = lane_width;
     std::unordered_map<std::size_t, std::unordered_set<std::size_t>> used_lanes;
     std::unordered_set<std::size_t> used_vertices;
-
+    
     for (std::size_t i=0; i < graph.num_waypoints(); ++i)
     {
       const auto& waypoint = graph.get_waypoint(i);
@@ -103,18 +106,16 @@ public:
       else
         text.setString(std::to_string(waypoint.index()));
       
-      sf::Vector2f scale(1.f/40.f, -1.f/40.f);
-      text.setScale(scale);
+      text.setScale(gTextScale);
       
       sf::FloatRect text_rect = text.getLocalBounds();
       text.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
-      text.setPosition(waypoint.get_location().x(), 
-        waypoint.get_location().y());
+      text.setPosition(waypoint.get_location().x(), waypoint.get_location().y());
 
       text.setFillColor(sf::Color(192, 192, 192));
 
       auto& map_data = data[waypoint.get_map_name()];
-      map_data.waypoints_text.emplace_back(text);
+      map_data.waypoints_text.emplace(waypoint.index(), text);
     }
 
     for (std::size_t i=0; i < graph.num_lanes(); ++i)
@@ -128,8 +129,29 @@ public:
 
       if (w0.get_map_name() != w1.get_map_name())
       {
-        // TODO(MXG): We should do something to indicate when a waypoint is
-        // connected to another map.
+        // add text that tells of a connection to another level
+        auto& w0_map_data = data[w0.get_map_name()];
+        auto& w0_text = w0_map_data.waypoints_text[j0];
+
+        auto& w1_map_data = data[w1.get_map_name()];
+        auto& w1_text = w1_map_data.waypoints_text[j1];
+        std::string w1_str = w1_text.getString();
+        
+        sf::Text text;
+        text.setFont(font);
+        text.setCharacterSize(w0_text.getCharacterSize());
+        text.setColor(sf::Color(144,238,144));
+        text.setString("[" + w1.get_map_name() + "::" + w1_str + "]");
+
+        sf::FloatRect text_rect = text.getLocalBounds();
+        text.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+
+        sf::FloatRect w0_text_rect = w0_text.getLocalBounds();
+        text.setPosition(w0.get_location().x(), 
+          w0.get_location().y() + w0_text_rect.height * gTextScale.y);
+        text.setScale(gTextScale);
+        
+        w0_map_data.connector_waypoints_text.emplace(j0, text);
         continue;
       }
 
@@ -461,7 +483,10 @@ void Graph::draw(sf::RenderTarget& target, sf::RenderStates states) const
     target.draw(s, states);
 
   for (const auto& s : map_data.waypoints_text)
-    target.draw(s, states);
+    target.draw(s.second, states);
+
+  for (const auto& s : map_data.connector_waypoints_text)
+    target.draw(s.second, states);
 }
 
 void Graph::set_text_size(uint sz)
@@ -471,10 +496,25 @@ void Graph::set_text_size(uint sz)
     auto& map_data = iter.second;
     for (auto& s : map_data.waypoints_text)
     {
-      s.setCharacterSize(sz);
+      sf::Text& text = s.second;
+      text.setCharacterSize(sz);
 
-      sf::FloatRect text_rect = s.getLocalBounds();
-      s.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+      sf::FloatRect text_rect = text.getLocalBounds();
+      text.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+    }
+
+    for (auto& s : map_data.connector_waypoints_text)
+    {
+      sf::Text& text = s.second;
+      text.setCharacterSize(sz);
+
+      sf::FloatRect text_rect = text.getLocalBounds();
+      text.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+      
+      sf::Text& parent_text = map_data.waypoints_text[s.first];
+      sf::FloatRect parent_rect = parent_text.getLocalBounds();
+      sf::Vector2f pos = parent_text.getPosition();
+      text.setPosition(pos.x, pos.y + parent_rect.height * gTextScale.y); 
     }
   }
 }

--- a/src/rmf_planner_viz/draw/Graph.cpp
+++ b/src/rmf_planner_viz/draw/Graph.cpp
@@ -94,7 +94,7 @@ public:
       const auto& waypoint = graph.get_waypoint(i);
       sf::Text text;
       text.setFont(font);
-      text.setCharacterSize(12);
+      text.setCharacterSize(24);
       if (waypoint.name())
       {
         std::string name = *waypoint.name();

--- a/src/rmf_planner_viz/draw/Graph.cpp
+++ b/src/rmf_planner_viz/draw/Graph.cpp
@@ -102,10 +102,15 @@ public:
       }
       else
         text.setString(std::to_string(waypoint.index()));
-      text.setPosition(waypoint.get_location().x(), waypoint.get_location().y());
+      
+      sf::Vector2f scale(1.f/40.f, -1.f/40.f);
+      text.setScale(scale);
+      
+      sf::FloatRect text_rect = text.getLocalBounds();
+      text.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+      text.setPosition(waypoint.get_location().x(), 
+        waypoint.get_location().y());
 
-      //minor scale hack
-      text.setScale(sf::Vector2f(1.f/40.f, -1.f/40.f));
       text.setFillColor(sf::Color(192, 192, 192));
 
       auto& map_data = data[waypoint.get_map_name()];
@@ -465,7 +470,12 @@ void Graph::set_text_size(uint sz)
   {
     auto& map_data = iter.second;
     for (auto& s : map_data.waypoints_text)
+    {
       s.setCharacterSize(sz);
+
+      sf::FloatRect text_rect = s.getLocalBounds();
+      s.setOrigin(text_rect.width * 0.5f, text_rect.height * 0.5f);
+    }
   }
 }
 

--- a/test/planner_debug.cpp
+++ b/test/planner_debug.cpp
@@ -33,6 +33,7 @@ namespace draw {
 
 void do_planner_debug(
   const rmf_traffic::Profile& profile, 
+  const std::string& chosen_map,
   rmf_traffic::agv::Planner& planner,
   std::vector<rmf_traffic::agv::Planner::Start>& starts,
   rmf_traffic::agv::Planner::Goal& goal,
@@ -295,6 +296,8 @@ void do_planner_debug(
       for (auto route : current_plan->get_itinerary())
       {
         const auto& traj = route.trajectory();
+        if (route.map() != chosen_map)
+          continue;
         auto trajectory = rmf_planner_viz::draw::Trajectory(traj,
           profile, trajectory_start_time, std::nullopt, sf::Color::Green, { 0.0, 0.0 }, 0.5f);
         trajectories_to_render.push_back(trajectory);

--- a/test/planner_debug.hpp
+++ b/test/planner_debug.hpp
@@ -47,7 +47,8 @@ S& get_priority_queue_container(std::priority_queue<T, S, C>& queue)
 }
 
 void do_planner_debug(
-  const rmf_traffic::Profile& profile, 
+  const rmf_traffic::Profile& profile,
+  const std::string& chosen_map,
   rmf_traffic::agv::Planner& planner,
   std::vector<rmf_traffic::agv::Planner::Start>& starts,
   rmf_traffic::agv::Planner::Goal& goal,

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -124,7 +124,8 @@ int main(int argc, char* argv[])
   }
 
   rmf_planner_viz::draw::Graph graph_0_drawable(graph_0, 1.0, font);
-
+  std::vector<std::string> map_names = graph_0_drawable.get_map_names();
+  
   std::shared_ptr<rmf_traffic::schedule::Database> database =
       std::make_shared<rmf_traffic::schedule::Database>();
 
@@ -269,7 +270,21 @@ int main(int argc, char* argv[])
         if (ImGui::InputInt("Text size", &sz))
         {
           if (sz > 0)
-            graph_0_drawable.set_text_size(sz);
+            graph_0_drawable.set_text_size((uint)sz);
+        }
+        ImGui::Separator();
+        ImGui::NewLine();
+
+        if (graph_0_drawable.current_map())
+        {
+          ImGui::Text("Maps");
+
+          for (uint i=0; i<map_names.size(); ++i)
+          {
+            bool activated = map_names[i] == *graph_0_drawable.current_map();
+            if (ImGui::RadioButton(map_names[i].c_str(), activated))
+              graph_0_drawable.choose_map(map_names[i]);
+          }
         }
         ImGui::EndMenu();
       }

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -257,12 +257,40 @@ int main(int argc, char* argv[])
         if (pick)
           graph_0_drawable.select(*pick);
       }
+
+      if (event.type == sf::Event::KeyReleased)
+      {
+        if (event.key.code == sf::Keyboard::F1)
+        {
+          for (uint i=0; i<map_names.size(); ++i)
+          {
+            if (map_names[i] != chosen_map)
+              continue;
+            if (i > 0)
+              chosen_map = map_names[i - 1];
+            else
+              chosen_map = map_names[map_names.size() - 1];
+            break;
+          }
+        }
+        if (event.key.code == sf::Keyboard::F2)
+        {
+          for (uint i=0; i<map_names.size(); ++i)
+          {
+            if (map_names[i] != chosen_map)
+              continue;
+            if (i < (map_names.size() - 1))
+              chosen_map = map_names[i + 1];
+            else
+              chosen_map = map_names[0];
+            break;
+          }
+        }
+      }
     }
 
     ImGui::SFML::Update(app_window, deltaClock.restart());
-    
-    static bool show_node_trajectories = true;
-    static std::vector<rmf_planner_viz::draw::Trajectory> trajectories_to_render;
+
 
     bool force_replan = false;
     if (ImGui::BeginMainMenuBar())
@@ -278,24 +306,22 @@ int main(int argc, char* argv[])
         ImGui::Separator();
         ImGui::NewLine();
 
-        if (graph_0_drawable.current_map())
-        {
-          ImGui::Text("Maps");
+        ImGui::Text("Maps (Use keys F1/F2 to iterate through)");
 
-          for (uint i=0; i<map_names.size(); ++i)
-          {
-            bool activated = map_names[i] == *graph_0_drawable.current_map();
-            if (ImGui::RadioButton(map_names[i].c_str(), activated))
-            {
-              graph_0_drawable.choose_map(map_names[i]);
-              chosen_map = map_names[i];
-            }
-          }
+        for (uint i=0; i<map_names.size(); ++i)
+        {
+          bool activated = map_names[i] == chosen_map;
+          if (ImGui::RadioButton(map_names[i].c_str(), activated))
+            chosen_map = map_names[i];
         }
         ImGui::EndMenu();
       }
       ImGui::EndMainMenuBar();
     }
+    graph_0_drawable.choose_map(chosen_map);
+    
+    static bool show_node_trajectories = true;
+    static std::vector<rmf_planner_viz::draw::Trajectory> trajectories_to_render;
 
     bool startgoal_force_replan = rmf_planner_viz::draw::do_planner_presets(starts, goal, plan_start_timing);
     force_replan |= startgoal_force_replan;

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
     {
       if (ImGui::BeginMenu("UI"))
       {
-        static int sz = 12;
+        static int sz = 24;
         if (ImGui::InputInt("Text size", &sz))
         {
           if (sz > 0)

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -125,6 +125,9 @@ int main(int argc, char* argv[])
 
   rmf_planner_viz::draw::Graph graph_0_drawable(graph_0, 1.0, font);
   std::vector<std::string> map_names = graph_0_drawable.get_map_names();
+  std::string chosen_map;
+  if (graph_0_drawable.current_map())
+    chosen_map = *graph_0_drawable.current_map();
   
   std::shared_ptr<rmf_traffic::schedule::Database> database =
       std::make_shared<rmf_traffic::schedule::Database>();
@@ -283,7 +286,10 @@ int main(int argc, char* argv[])
           {
             bool activated = map_names[i] == *graph_0_drawable.current_map();
             if (ImGui::RadioButton(map_names[i].c_str(), activated))
+            {
               graph_0_drawable.choose_map(map_names[i]);
+              chosen_map = map_names[i];
+            }
           }
         }
         ImGui::EndMenu();
@@ -295,7 +301,8 @@ int main(int argc, char* argv[])
     force_replan |= startgoal_force_replan;
 
     rmf_planner_viz::draw::do_planner_debug(
-      profile, planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, plan_start_timing,
+      profile, chosen_map,
+      planner_0, starts, goal, graph_0.num_waypoints(), planner_debug, progress, plan_start_timing,
       force_replan, show_node_trajectories, trajectories_to_render);
     
     ImGui::EndFrame();

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
   const std::string test_map_name = "test_map";
   if (argc == 2)
   {
-    std::cout << "Loading map file " << argv[1] << std::endl;
+    std::cout << "Loading nav_graph file " << argv[1] << std::endl;
     graph_0 = rmf_fleet_adapter::agv::parse_graph(
       argv[1], 
       traits);


### PR DESCRIPTION
depends on #7 
other changes
- text size changed to 24
- F1/F2 keys now iterate through the map
- trajectories also filter based on map

consider commits from d79d9d1

![connector](https://user-images.githubusercontent.com/3326941/103620810-1eb3dc00-4f6f-11eb-9dbe-4fcfbb1e0c5a.png)
![selection](https://user-images.githubusercontent.com/3326941/103620815-207d9f80-4f6f-11eb-9210-708b442bc766.png)
